### PR TITLE
zsh, tmux: claude workspace検出とpane label連携

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,14 @@ karabiner/automatic_backups/
 anyenv/
 fish/
 raycast/
+
+# machine-local private config
+zsh/.zshrc.local
+
+# AWS VPN
+AWS VPN Client/
+AWSVPNClient/
+
+# backup / scratch
+nvim.bak/
+q/

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -27,7 +27,7 @@ set -g pane-border-lines heavy
 set -g pane-border-indicators both
 set -g pane-border-style "fg=colour238"
 set -g pane-active-border-style "fg=colour81"
-set -g pane-border-format '#{?pane_active,#[fg=colour16,bg=colour81,bold],#[fg=colour252,bg=colour238]} #{pane_title} #[default]'
+set -g pane-border-format '#{?@pane_label,#{?pane_active,#[fg=colour231,bg=colour33,bold],#[fg=colour252,bg=colour238]} #{@pane_label} #[default],#{?pane_active,#[fg=colour231,bg=colour33,bold],#[fg=colour252,bg=colour238]} #{pane_current_path} #{?#{!=:#{pane_title},#{host}},| #{pane_title} ,}#[default]}'
 
 # Resize pane
 bind -n M-Left resize-pane -L

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -260,6 +260,50 @@ _prompt_codex_segment() {
     _prompt_segment "16" "45" "codex"
 }
 
+_prompt_in_claude_workspace() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -f "$dir/CLAUDE.md" ]]; then
+            return 0
+        fi
+        dir="${dir:h}"
+    done
+
+    return 1
+}
+
+_prompt_claude_name() {
+    if [[ -n "$CLAUDE_NAME" ]]; then
+        echo "$CLAUDE_NAME"
+        return
+    fi
+
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -f "$dir/.claude-name" ]]; then
+            local name
+            name=$(<"$dir/.claude-name")
+            name="${name%%$'\n'*}"
+            [[ -n "$name" ]] && echo "$name"
+            return
+        fi
+        dir="${dir:h}"
+    done
+}
+
+_prompt_claude_segment() {
+    _prompt_in_claude_workspace || return
+    local claude_name
+    claude_name="$(_prompt_claude_name)"
+
+    if [[ -n "$claude_name" ]]; then
+        _prompt_segment "16" "208" "claude:${claude_name}"
+        return
+    fi
+
+    _prompt_segment "16" "208" "claude"
+}
+
 _prompt_git_segment() {
     command git rev-parse --is-inside-work-tree >/dev/null 2>&1 || return
 
@@ -293,7 +337,7 @@ _prompt_time_segment() {
 }
 
 _prompt_line_one() {
-    local accent context_fg label session_segment path_segment git_segment codex_segment runtime_segment permission_segment status_segment duration_segment time_segment
+    local accent context_fg label session_segment path_segment git_segment codex_segment claude_segment runtime_segment permission_segment status_segment duration_segment time_segment
     accent="$(_prompt_context_accent)"
     context_fg="$(_prompt_context_fg)"
     label="$(_prompt_path_label)"
@@ -301,13 +345,14 @@ _prompt_line_one() {
     path_segment="$(_prompt_segment "$context_fg" "$accent" "$label %~")"
     git_segment="$(_prompt_git_segment)"
     codex_segment="$(_prompt_codex_segment)"
+    claude_segment="$(_prompt_claude_segment)"
     runtime_segment="$(_prompt_runtime_segment)"
     permission_segment="$(_prompt_permission_segment)"
     status_segment="$(_prompt_status_segment)"
     duration_segment="$(_prompt_duration_segment)"
     time_segment="$(_prompt_time_segment)"
 
-    echo "╭─${session_segment}${path_segment}${git_segment}${codex_segment}${runtime_segment}${permission_segment}${status_segment}${duration_segment}${time_segment}"
+    echo "╭─${session_segment}${path_segment}${git_segment}${codex_segment}${claude_segment}${runtime_segment}${permission_segment}${status_segment}${duration_segment}${time_segment}"
 }
 
 _prompt_line_two() {
@@ -421,13 +466,28 @@ if [[ -n "$TMUX" ]]; then
         echo "#[fg=colour16,bg=colour45] codex #[default]"
     }
 
+    function _tmux_claude_label() {
+        _prompt_in_claude_workspace || return
+        local claude_name
+        claude_name="$(_prompt_claude_name)"
+
+        if [[ -n "$claude_name" ]]; then
+            echo "#[fg=colour16,bg=colour208] claude:${claude_name} #[default]"
+            return
+        fi
+
+        echo "#[fg=colour16,bg=colour208] claude #[default]"
+    }
+
     function _update_tmux_pane_title() {
         local path_style="$(_tmux_path_style_for_pwd)"
         local path_label="$(_tmux_path_label_for_pwd)"
         local git_label="$(_tmux_git_label)"
         local codex_label="$(_tmux_codex_label)"
+        local claude_label="$(_tmux_claude_label)"
 
-        tmux select-pane -T "${path_style} ${path_label} #[default]${git_label}${codex_label}" 2>/dev/null
+        local label="${path_style} ${path_label} #[default]${git_label}${codex_label}${claude_label}"
+        tmux set-option -p @pane_label "$label" 2>/dev/null
     }
     autoload -Uz add-zsh-hook
     add-zsh-hook precmd _update_tmux_pane_title

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -82,6 +82,13 @@ done
 
 source $ZSH/oh-my-zsh.sh
 
+# Load machine-local private config (paths, aliases)
+[[ -f "$HOME/.config/zsh/.zshrc.local" ]] && source "$HOME/.config/zsh/.zshrc.local"
+
+# Defaults for context directories (overridden by .zshrc.local)
+: "${DOTFILES_WORK_DIR:=$HOME/work}"
+: "${DOTFILES_OBSIDIAN_DIR:=$HOME/obsidian}"
+
 if [[ -d "$HOME/.config/bin" ]]; then
     path=("$HOME/.config/bin" $path)
 fi
@@ -129,10 +136,10 @@ typeset -g PROMPT_CMD_DURATION=""
 
 _prompt_context_accent() {
     case "$PWD" in
-        "$HOME/Desktop/work"(|/*))
+        "${DOTFILES_WORK_DIR}"(|/*))
             echo "24"
             ;;
-        "$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents"(|/*))
+        "${DOTFILES_OBSIDIAN_DIR}"(|/*))
             echo "58"
             ;;
         "$HOME"(|/*))
@@ -146,10 +153,10 @@ _prompt_context_accent() {
 
 _prompt_context_fg() {
     case "$PWD" in
-        "$HOME/Desktop/work"(|/*))
+        "${DOTFILES_WORK_DIR}"(|/*))
             echo "231"
             ;;
-        "$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents"(|/*))
+        "${DOTFILES_OBSIDIAN_DIR}"(|/*))
             echo "231"
             ;;
         "$HOME"(|/*))
@@ -163,10 +170,10 @@ _prompt_context_fg() {
 
 _prompt_path_label() {
     case "$PWD" in
-        "$HOME/Desktop/work"(|/*))
+        "${DOTFILES_WORK_DIR}"(|/*))
             echo "WORK"
             ;;
-        "$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents"(|/*))
+        "${DOTFILES_OBSIDIAN_DIR}"(|/*))
             echo "OBSIDIAN"
             ;;
         "$HOME"(|/*))
@@ -396,17 +403,13 @@ RPROMPT=
 # Kiro CLI post block. Keep at the bottom of this file.
 [[ -f "${HOME}/Library/Application Support/kiro-cli/shell/zshrc.post.zsh" ]] && builtin source "${HOME}/Library/Application Support/kiro-cli/shell/zshrc.post.zsh"
 
-# Obsidian AI Agent Aliases
-alias vp='cd "/Users/kota/Library/Mobile Documents/iCloud~md~obsidian/Documents" && claude'
-alias vw='cd "/Users/kota/Desktop/work" && claude'
-
 if [[ -n "$TMUX" ]]; then
     function _tmux_path_style_for_pwd() {
         case "$PWD" in
-            "$HOME/Desktop/work"(|/*))
+            "${DOTFILES_WORK_DIR}"(|/*))
                 echo "#[fg=colour230,bg=colour24]"
                 ;;
-            "$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents"(|/*))
+            "${DOTFILES_OBSIDIAN_DIR}"(|/*))
                 echo "#[fg=colour230,bg=colour58]"
                 ;;
             "$HOME"(|/*))
@@ -425,10 +428,10 @@ if [[ -n "$TMUX" ]]; then
         fi
 
         case "$PWD" in
-            "$HOME/Desktop/work"(|/*))
+            "${DOTFILES_WORK_DIR}"(|/*))
                 echo "work ${PWD:t}"
                 ;;
-            "$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents"(|/*))
+            "${DOTFILES_OBSIDIAN_DIR}"(|/*))
                 echo "obsidian ${PWD:t}"
                 ;;
             "$HOME"(|/*))

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -86,8 +86,13 @@ source $ZSH/oh-my-zsh.sh
 [[ -f "$HOME/.config/zsh/.zshrc.local" ]] && source "$HOME/.config/zsh/.zshrc.local"
 
 # Defaults for context directories (overridden by .zshrc.local)
-: "${DOTFILES_WORK_DIR:=$HOME/work}"
-: "${DOTFILES_OBSIDIAN_DIR:=$HOME/obsidian}"
+: "${DOTFILES_WORK_VAULT:=$HOME/work}"
+: "${DOTFILES_PRIVATE_VAULT:=$HOME/obsidian}"
+# Normalize: expand to absolute paths and strip trailing slashes
+DOTFILES_WORK_VAULT=${DOTFILES_WORK_VAULT:A}
+DOTFILES_WORK_VAULT=${DOTFILES_WORK_VAULT%/}
+DOTFILES_PRIVATE_VAULT=${DOTFILES_PRIVATE_VAULT:A}
+DOTFILES_PRIVATE_VAULT=${DOTFILES_PRIVATE_VAULT%/}
 
 if [[ -d "$HOME/.config/bin" ]]; then
     path=("$HOME/.config/bin" $path)
@@ -136,10 +141,10 @@ typeset -g PROMPT_CMD_DURATION=""
 
 _prompt_context_accent() {
     case "$PWD" in
-        "${DOTFILES_WORK_DIR}"(|/*))
+        "${DOTFILES_WORK_VAULT}"(|/*))
             echo "24"
             ;;
-        "${DOTFILES_OBSIDIAN_DIR}"(|/*))
+        "${DOTFILES_PRIVATE_VAULT}"(|/*))
             echo "58"
             ;;
         "$HOME"(|/*))
@@ -153,10 +158,10 @@ _prompt_context_accent() {
 
 _prompt_context_fg() {
     case "$PWD" in
-        "${DOTFILES_WORK_DIR}"(|/*))
+        "${DOTFILES_WORK_VAULT}"(|/*))
             echo "231"
             ;;
-        "${DOTFILES_OBSIDIAN_DIR}"(|/*))
+        "${DOTFILES_PRIVATE_VAULT}"(|/*))
             echo "231"
             ;;
         "$HOME"(|/*))
@@ -170,10 +175,10 @@ _prompt_context_fg() {
 
 _prompt_path_label() {
     case "$PWD" in
-        "${DOTFILES_WORK_DIR}"(|/*))
+        "${DOTFILES_WORK_VAULT}"(|/*))
             echo "WORK"
             ;;
-        "${DOTFILES_OBSIDIAN_DIR}"(|/*))
+        "${DOTFILES_PRIVATE_VAULT}"(|/*))
             echo "OBSIDIAN"
             ;;
         "$HOME"(|/*))
@@ -406,10 +411,10 @@ RPROMPT=
 if [[ -n "$TMUX" ]]; then
     function _tmux_path_style_for_pwd() {
         case "$PWD" in
-            "${DOTFILES_WORK_DIR}"(|/*))
+            "${DOTFILES_WORK_VAULT}"(|/*))
                 echo "#[fg=colour230,bg=colour24]"
                 ;;
-            "${DOTFILES_OBSIDIAN_DIR}"(|/*))
+            "${DOTFILES_PRIVATE_VAULT}"(|/*))
                 echo "#[fg=colour230,bg=colour58]"
                 ;;
             "$HOME"(|/*))
@@ -428,10 +433,10 @@ if [[ -n "$TMUX" ]]; then
         fi
 
         case "$PWD" in
-            "${DOTFILES_WORK_DIR}"(|/*))
+            "${DOTFILES_WORK_VAULT}"(|/*))
                 echo "work ${PWD:t}"
                 ;;
-            "${DOTFILES_OBSIDIAN_DIR}"(|/*))
+            "${DOTFILES_PRIVATE_VAULT}"(|/*))
                 echo "obsidian ${PWD:t}"
                 ;;
             "$HOME"(|/*))

--- a/zsh/.zshrc.local.example
+++ b/zsh/.zshrc.local.example
@@ -1,0 +1,12 @@
+# zsh/.zshrc.local.example — copy to .zshrc.local and edit
+#
+# This file is sourced by .zshrc for machine-specific paths and aliases.
+# It is gitignored and never pushed.
+
+# Context directories for prompt coloring
+DOTFILES_WORK_DIR="$HOME/work"
+DOTFILES_OBSIDIAN_DIR="$HOME/obsidian"
+
+# Quick-launch aliases (optional)
+# alias vw='cd "$DOTFILES_WORK_DIR" && claude'
+# alias vp='cd "$DOTFILES_OBSIDIAN_DIR" && claude'

--- a/zsh/.zshrc.local.example
+++ b/zsh/.zshrc.local.example
@@ -1,12 +1,12 @@
-# zsh/.zshrc.local.example — copy to .zshrc.local and edit
+# zsh/.zshrc.local.example — copy to ~/.config/zsh/.zshrc.local and edit
 #
-# This file is sourced by .zshrc for machine-specific paths and aliases.
+# This file is sourced by ~/.config/zsh/.zshrc for machine-specific paths and aliases.
 # It is gitignored and never pushed.
 
 # Context directories for prompt coloring
-DOTFILES_WORK_DIR="$HOME/work"
-DOTFILES_OBSIDIAN_DIR="$HOME/obsidian"
+DOTFILES_WORK_VAULT="$HOME/work"
+DOTFILES_PRIVATE_VAULT="$HOME/obsidian"
 
 # Quick-launch aliases (optional)
-# alias vw='cd "$DOTFILES_WORK_DIR" && claude'
-# alias vp='cd "$DOTFILES_OBSIDIAN_DIR" && claude'
+# alias vw='cd "$DOTFILES_WORK_VAULT" && claude'
+# alias vp='cd "$DOTFILES_PRIVATE_VAULT" && claude'


### PR DESCRIPTION
## Summary
- CLAUDE.mdの有無でプロンプト/tmuxペインに `claude:名前` ラベルを表示
- tmux pane-border-formatを `@pane_label` ベースに切替（zsh側で動的セット）

## Test plan
- [x] CLAUDE.mdがあるディレクトリでプロンプトに `claude` セグメントが表示されること
- [x] `.claude-name` があれば `claude:名前` 形式になること
- [x] tmuxペインボーダーに @pane_label の内容が反映されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)