### PR TITLE
zsh: 業務パスをマスクし.zshrc.localに分離

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,14 @@ karabiner/automatic_backups/
 anyenv/
 fish/
 raycast/
+
+# machine-local private config
+zsh/.zshrc.local
+
+# AWS VPN
+AWS VPN Client/
+AWSVPNClient/
+
+# backup / scratch
+nvim.bak/
+q/

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -82,6 +82,13 @@ done
 
 source $ZSH/oh-my-zsh.sh
 
+# Load machine-local private config (paths, aliases)
+[[ -f "$HOME/.config/zsh/.zshrc.local" ]] && source "$HOME/.config/zsh/.zshrc.local"
+
+# Defaults for context directories (overridden by .zshrc.local)
+: "${DOTFILES_WORK_DIR:=$HOME/work}"
+: "${DOTFILES_OBSIDIAN_DIR:=$HOME/obsidian}"
+
 if [[ -d "$HOME/.config/bin" ]]; then
     path=("$HOME/.config/bin" $path)
 fi
@@ -129,10 +136,10 @@ typeset -g PROMPT_CMD_DURATION=""
 
 _prompt_context_accent() {
     case "$PWD" in
-        "$HOME/Desktop/work"(|/*))
+        "${DOTFILES_WORK_DIR}"(|/*))
             echo "24"
             ;;
-        "$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents"(|/*))
+        "${DOTFILES_OBSIDIAN_DIR}"(|/*))
             echo "58"
             ;;
         "$HOME"(|/*))
@@ -146,10 +153,10 @@ _prompt_context_accent() {
 
 _prompt_context_fg() {
     case "$PWD" in
-        "$HOME/Desktop/work"(|/*))
+        "${DOTFILES_WORK_DIR}"(|/*))
             echo "231"
             ;;
-        "$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents"(|/*))
+        "${DOTFILES_OBSIDIAN_DIR}"(|/*))
             echo "231"
             ;;
         "$HOME"(|/*))
@@ -163,10 +170,10 @@ _prompt_context_fg() {
 
 _prompt_path_label() {
     case "$PWD" in
-        "$HOME/Desktop/work"(|/*))
+        "${DOTFILES_WORK_DIR}"(|/*))
             echo "WORK"
             ;;
-        "$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents"(|/*))
+        "${DOTFILES_OBSIDIAN_DIR}"(|/*))
             echo "OBSIDIAN"
             ;;
         "$HOME"(|/*))
@@ -396,17 +403,13 @@ RPROMPT=
 # Kiro CLI post block. Keep at the bottom of this file.
 [[ -f "${HOME}/Library/Application Support/kiro-cli/shell/zshrc.post.zsh" ]] && builtin source "${HOME}/Library/Application Support/kiro-cli/shell/zshrc.post.zsh"
 
-# Obsidian AI Agent Aliases
-alias vp='cd "/Users/kota/Library/Mobile Documents/iCloud~md~obsidian/Documents" && claude'
-alias vw='cd "/Users/kota/Desktop/work" && claude'
-
 if [[ -n "$TMUX" ]]; then
     function _tmux_path_style_for_pwd() {
         case "$PWD" in
-            "$HOME/Desktop/work"(|/*))
+            "${DOTFILES_WORK_DIR}"(|/*))
                 echo "#[fg=colour230,bg=colour24]"
                 ;;
-            "$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents"(|/*))
+            "${DOTFILES_OBSIDIAN_DIR}"(|/*))
                 echo "#[fg=colour230,bg=colour58]"
                 ;;
             "$HOME"(|/*))
@@ -425,10 +428,10 @@ if [[ -n "$TMUX" ]]; then
         fi
 
         case "$PWD" in
-            "$HOME/Desktop/work"(|/*))
+            "${DOTFILES_WORK_DIR}"(|/*))
                 echo "work ${PWD:t}"
                 ;;
-            "$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents"(|/*))
+            "${DOTFILES_OBSIDIAN_DIR}"(|/*))
                 echo "obsidian ${PWD:t}"
                 ;;
             "$HOME"(|/*))

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -86,8 +86,13 @@ source $ZSH/oh-my-zsh.sh
 [[ -f "$HOME/.config/zsh/.zshrc.local" ]] && source "$HOME/.config/zsh/.zshrc.local"
 
 # Defaults for context directories (overridden by .zshrc.local)
-: "${DOTFILES_WORK_DIR:=$HOME/work}"
-: "${DOTFILES_OBSIDIAN_DIR:=$HOME/obsidian}"
+: "${DOTFILES_WORK_VAULT:=$HOME/work}"
+: "${DOTFILES_PRIVATE_VAULT:=$HOME/obsidian}"
+# Normalize: expand to absolute paths and strip trailing slashes
+DOTFILES_WORK_VAULT=${DOTFILES_WORK_VAULT:A}
+DOTFILES_WORK_VAULT=${DOTFILES_WORK_VAULT%/}
+DOTFILES_PRIVATE_VAULT=${DOTFILES_PRIVATE_VAULT:A}
+DOTFILES_PRIVATE_VAULT=${DOTFILES_PRIVATE_VAULT%/}
 
 if [[ -d "$HOME/.config/bin" ]]; then
     path=("$HOME/.config/bin" $path)
@@ -136,10 +141,10 @@ typeset -g PROMPT_CMD_DURATION=""
 
 _prompt_context_accent() {
     case "$PWD" in
-        "${DOTFILES_WORK_DIR}"(|/*))
+        "${DOTFILES_WORK_VAULT}"(|/*))
             echo "24"
             ;;
-        "${DOTFILES_OBSIDIAN_DIR}"(|/*))
+        "${DOTFILES_PRIVATE_VAULT}"(|/*))
             echo "58"
             ;;
         "$HOME"(|/*))
@@ -153,10 +158,10 @@ _prompt_context_accent() {
 
 _prompt_context_fg() {
     case "$PWD" in
-        "${DOTFILES_WORK_DIR}"(|/*))
+        "${DOTFILES_WORK_VAULT}"(|/*))
             echo "231"
             ;;
-        "${DOTFILES_OBSIDIAN_DIR}"(|/*))
+        "${DOTFILES_PRIVATE_VAULT}"(|/*))
             echo "231"
             ;;
         "$HOME"(|/*))
@@ -170,10 +175,10 @@ _prompt_context_fg() {
 
 _prompt_path_label() {
     case "$PWD" in
-        "${DOTFILES_WORK_DIR}"(|/*))
+        "${DOTFILES_WORK_VAULT}"(|/*))
             echo "WORK"
             ;;
-        "${DOTFILES_OBSIDIAN_DIR}"(|/*))
+        "${DOTFILES_PRIVATE_VAULT}"(|/*))
             echo "OBSIDIAN"
             ;;
         "$HOME"(|/*))
@@ -406,10 +411,10 @@ RPROMPT=
 if [[ -n "$TMUX" ]]; then
     function _tmux_path_style_for_pwd() {
         case "$PWD" in
-            "${DOTFILES_WORK_DIR}"(|/*))
+            "${DOTFILES_WORK_VAULT}"(|/*))
                 echo "#[fg=colour230,bg=colour24]"
                 ;;
-            "${DOTFILES_OBSIDIAN_DIR}"(|/*))
+            "${DOTFILES_PRIVATE_VAULT}"(|/*))
                 echo "#[fg=colour230,bg=colour58]"
                 ;;
             "$HOME"(|/*))
@@ -428,10 +433,10 @@ if [[ -n "$TMUX" ]]; then
         fi
 
         case "$PWD" in
-            "${DOTFILES_WORK_DIR}"(|/*))
+            "${DOTFILES_WORK_VAULT}"(|/*))
                 echo "work ${PWD:t}"
                 ;;
-            "${DOTFILES_OBSIDIAN_DIR}"(|/*))
+            "${DOTFILES_PRIVATE_VAULT}"(|/*))
                 echo "obsidian ${PWD:t}"
                 ;;
             "$HOME"(|/*))

--- a/zsh/.zshrc.local.example
+++ b/zsh/.zshrc.local.example
@@ -1,0 +1,12 @@
+# zsh/.zshrc.local.example — copy to .zshrc.local and edit
+#
+# This file is sourced by .zshrc for machine-specific paths and aliases.
+# It is gitignored and never pushed.
+
+# Context directories for prompt coloring
+DOTFILES_WORK_DIR="$HOME/work"
+DOTFILES_OBSIDIAN_DIR="$HOME/obsidian"
+
+# Quick-launch aliases (optional)
+# alias vw='cd "$DOTFILES_WORK_DIR" && claude'
+# alias vp='cd "$DOTFILES_OBSIDIAN_DIR" && claude'

--- a/zsh/.zshrc.local.example
+++ b/zsh/.zshrc.local.example
@@ -1,12 +1,12 @@
-# zsh/.zshrc.local.example — copy to .zshrc.local and edit
+# zsh/.zshrc.local.example — copy to ~/.config/zsh/.zshrc.local and edit
 #
-# This file is sourced by .zshrc for machine-specific paths and aliases.
+# This file is sourced by ~/.config/zsh/.zshrc for machine-specific paths and aliases.
 # It is gitignored and never pushed.
 
 # Context directories for prompt coloring
-DOTFILES_WORK_DIR="$HOME/work"
-DOTFILES_OBSIDIAN_DIR="$HOME/obsidian"
+DOTFILES_WORK_VAULT="$HOME/work"
+DOTFILES_PRIVATE_VAULT="$HOME/obsidian"
 
 # Quick-launch aliases (optional)
-# alias vw='cd "$DOTFILES_WORK_DIR" && claude'
-# alias vp='cd "$DOTFILES_OBSIDIAN_DIR" && claude'
+# alias vw='cd "$DOTFILES_WORK_VAULT" && claude'
+# alias vp='cd "$DOTFILES_PRIVATE_VAULT" && claude'


### PR DESCRIPTION
## Summary
- ハードコードされていた作業ディレクトリ・Obsidianパスを `$DOTFILES_WORK_DIR` / `$DOTFILES_OBSIDIAN_DIR` 変数に置換
- マシン固有のパスとエイリアス（`vp`, `vw`）をgitignored の `.zshrc.local` に移動
- `.zshrc.local.example` をテンプレートとして追加
- `.gitignore` にAWS VPN、nvim.bak等を追加

## Test plan
- [ ] `grep -r 'Desktop/work\|iCloud~md~obsidian\|/Users/kota' zsh/.zshrc` で該当なし
- [ ] `.zshrc.local` があればパス・エイリアスが正常動作すること
- [ ] `.zshrc.local` がなくてもデフォルト値でエラーなく起動すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)