### PR TITLE
業務パスマスク・各種設定の改善

### DIFF
--- a/ccstatusline/settings.json
+++ b/ccstatusline/settings.json
@@ -3,14 +3,6 @@
   "lines": [
     [
       {
-        "id": "9b9c0b41-f3e4-4757-a0bf-2badaec22615",
-        "type": "claude-session-id"
-      },
-      {
-        "id": "d55a4159-0132-4e2d-b3ba-3efd3ac5035a",
-        "type": "separator"
-      },
-      {
         "id": "1",
         "type": "model",
         "color": "cyan"
@@ -25,85 +17,26 @@
         "color": "brightBlack"
       },
       {
-        "id": "ef9258b3-cef0-4c69-824d-0e52a300f9c8",
+        "id": "4",
         "type": "separator"
       },
       {
-        "id": "334c4a4b-e130-44c4-bae1-1cc01663e6df",
-        "type": "context-percentage"
+        "id": "5",
+        "type": "git-branch",
+        "color": "magenta"
       },
       {
-        "id": "3234b419-96b3-4bd2-a7a9-3736ece38fc9",
+        "id": "6",
         "type": "separator"
       },
       {
-        "id": "bae2f353-551e-432b-bc8b-231126a15665",
-        "type": "context-bar"
+        "id": "7",
+        "type": "git-changes",
+        "color": "yellow"
       }
     ],
-    [
-      {
-        "id": "f4f0f5f0-b240-459e-8568-ed1fd90ac1bd",
-        "type": "git-root-dir"
-      },
-      {
-        "id": "3626adf1-3617-451e-af8f-b776a74bff6b",
-        "type": "separator"
-      },
-      {
-        "id": "9ae83fc1-b7ff-4790-8c42-ba4727447a3f",
-        "type": "git-worktree"
-      },
-      {
-        "id": "ff2fa8b5-bc63-4de4-8e20-fc3acbf48939",
-        "type": "separator"
-      },
-      {
-        "id": "a54cc3e9-ace9-4829-97e4-4ea6b7d423bb",
-        "type": "git-changes"
-      },
-      {
-        "id": "e38a1305-0773-40c3-b24b-f031d95ca565",
-        "type": "separator"
-      },
-      {
-        "id": "4ad052e0-fbfc-4488-a02f-4f1a8dce0e45",
-        "type": "vim-mode"
-      }
-    ],
-    [
-      {
-        "id": "a3bb976c-4a64-4797-8322-9a3749e4d933",
-        "type": "session-clock"
-      },
-      {
-        "id": "cd59e703-bbac-4a57-b1ae-4e8315c7315b",
-        "type": "separator"
-      },
-      {
-        "id": "9fb97edf-676c-4c2f-82a8-6cd9365211f4",
-        "type": "session-name"
-      },
-      {
-        "id": "bb7b60cb-0c35-498f-a6d4-146d6a550d4a",
-        "type": "separator"
-      },
-      {
-        "id": "ddb87eac-00fc-4326-92bf-f8d171fadae2",
-        "type": "skills",
-        "metadata": {
-          "mode": "list"
-        }
-      },
-      {
-        "id": "297fc8cc-ddeb-4d7a-8d09-2a161ad12b73",
-        "type": "separator"
-      },
-      {
-        "id": "75408e92-19f3-4ad3-bf71-2f5859345214",
-        "type": "weekly-usage"
-      }
-    ]
+    [],
+    []
   ],
   "flexMode": "full-minus-40",
   "compactThreshold": 60,

--- a/ghostty/config
+++ b/ghostty/config
@@ -1,4 +1,7 @@
 macos-option-as-alt = true
-
 shell-integration-features = ssh-terminfo
-
+background-opacity = 0.7
+macos-non-native-fullscreen = true
+window-decoration = true
+macos-titlebar-style = transparent
+window-save-state = always

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -251,17 +251,22 @@ _prompt_in_codex_workspace() {
 }
 
 _prompt_codex_name() {
+    local name=""
     if [[ -n "$CODEX_NAME" ]]; then
-        echo "$CODEX_NAME"
-        return
+        name="$CODEX_NAME"
+    else
+        local found
+        found="$(_find_upward_file ".codex-name")" || return
+        name=$(<"$found")
+        name="${name%%$'\n'*}"
     fi
 
-    local found
-    found="$(_find_upward_file ".codex-name")" || return
-    local name
-    name=$(<"$found")
-    name="${name%%$'\n'*}"
-    [[ -n "$name" ]] && echo "$name"
+    if [[ -n "$name" ]]; then
+        name="${name//[[:cntrl:]]/}"
+        name="${name:0:32}"
+        name="${name//\%/%%}"
+        echo "$name"
+    fi
 }
 
 _prompt_codex_segment() {

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -1,7 +1,7 @@
 # Kiro CLI pre block. Keep at the top of this file.
 [[ -f "${HOME}/Library/Application Support/kiro-cli/shell/zshrc.pre.zsh" ]] && builtin source "${HOME}/Library/Application Support/kiro-cli/shell/zshrc.pre.zsh"
 # If you come from bash you might have to change your $PATH.
-# export PATH=$HOME/bin:$HOME/.local/bin:/usr/local/bin:$PATH
+export PATH=$HOME/bin:$HOME/.local/bin:/usr/local/bin:$PATH
 
 # Path to your Oh My Zsh installation.
 export ZSH="$HOME/.oh-my-zsh"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -233,16 +233,21 @@ _prompt_runtime_segment() {
     fi
 }
 
-_prompt_in_codex_workspace() {
+_find_upward_file() {
+    local target="$1"
     local dir="$PWD"
     while [[ "$dir" != "/" ]]; do
-        if [[ -f "$dir/AGENTS.md" ]]; then
+        if [[ -f "$dir/$target" ]]; then
+            echo "$dir/$target"
             return 0
         fi
         dir="${dir:h}"
     done
-
     return 1
+}
+
+_prompt_in_codex_workspace() {
+    _find_upward_file "AGENTS.md" >/dev/null
 }
 
 _prompt_codex_name() {
@@ -251,17 +256,12 @@ _prompt_codex_name() {
         return
     fi
 
-    local dir="$PWD"
-    while [[ "$dir" != "/" ]]; do
-        if [[ -f "$dir/.codex-name" ]]; then
-            local name
-            name=$(<"$dir/.codex-name")
-            name="${name%%$'\n'*}"
-            [[ -n "$name" ]] && echo "$name"
-            return
-        fi
-        dir="${dir:h}"
-    done
+    local found
+    found="$(_find_upward_file ".codex-name")" || return
+    local name
+    name=$(<"$found")
+    name="${name%%$'\n'*}"
+    [[ -n "$name" ]] && echo "$name"
 }
 
 _prompt_codex_segment() {
@@ -278,34 +278,26 @@ _prompt_codex_segment() {
 }
 
 _prompt_in_claude_workspace() {
-    local dir="$PWD"
-    while [[ "$dir" != "/" ]]; do
-        if [[ -f "$dir/CLAUDE.md" ]]; then
-            return 0
-        fi
-        dir="${dir:h}"
-    done
-
-    return 1
+    _find_upward_file "CLAUDE.md" >/dev/null
 }
 
 _prompt_claude_name() {
+    local name=""
     if [[ -n "$CLAUDE_NAME" ]]; then
-        echo "$CLAUDE_NAME"
-        return
+        name="$CLAUDE_NAME"
+    else
+        local found
+        found="$(_find_upward_file ".claude-name")" || return
+        name=$(<"$found")
+        name="${name%%$'\n'*}"
     fi
 
-    local dir="$PWD"
-    while [[ "$dir" != "/" ]]; do
-        if [[ -f "$dir/.claude-name" ]]; then
-            local name
-            name=$(<"$dir/.claude-name")
-            name="${name%%$'\n'*}"
-            [[ -n "$name" ]] && echo "$name"
-            return
-        fi
-        dir="${dir:h}"
-    done
+    if [[ -n "$name" ]]; then
+        name="${name//[[:cntrl:]]/}"
+        name="${name:0:32}"
+        name="${name//\%/%%}"
+        echo "$name"
+    fi
 }
 
 _prompt_claude_segment() {
@@ -485,6 +477,7 @@ if [[ -n "$TMUX" ]]; then
         claude_name="$(_prompt_claude_name)"
 
         if [[ -n "$claude_name" ]]; then
+            claude_name="${claude_name//#/##}"
             echo "#[fg=colour16,bg=colour208] claude:${claude_name} #[default]"
             return
         fi


### PR DESCRIPTION
## Summary
- zsh: 業務パスのマスク処理を追加し、`.zshrc.local`に分離。PATH exportを有効化
- zsh/tmux: Claude workspace検出とpane label連携
- zsh: codex/claude名のサニタイズ処理、共通ヘルパー抽出
- ghostty: 背景透過・フルスクリーン・タイトルバー設定を追加
- nvim: プラグイン更新 & markdownタブインデント設定（サブモジュールポインタ更新）
- ccstatusline: Claude Codeステータスライン設定を追加

## Test plan
- [x] zshrcの読み込みが正常に動作すること
- [x] ghosttyの設定が反映されること
- [x] nvimのプラグインが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)