### PR TITLE
zsh: Agent Map — 起動時にエージェント配置テーブルを表示

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -645,3 +645,19 @@ codex() {
 
   command codex "$@"
 }
+
+# ── Agent Map: 起動時表示 ─────────────────────────────────────────────────────
+_AGENT_MAP_CACHE="$HOME/.cache/agent_map"
+_AGENT_MAP_GEN="$HOME/.config/zsh/agent_map_gen"
+if [[ -f "$_AGENT_MAP_CACHE" ]]; then
+  cat "$_AGENT_MAP_CACHE"
+  # キャッシュが1時間以上古ければバックグラウンドで更新（表示はブロックしない）
+  if (( $(date +%s) - $(stat -f %m "$_AGENT_MAP_CACHE") > 3600 )); then
+    zsh "$_AGENT_MAP_GEN" > "$_AGENT_MAP_CACHE" &!
+  fi
+else
+  # 初回: 同期生成してキャッシュ保存
+  mkdir -p "${_AGENT_MAP_CACHE:h}"
+  zsh "$_AGENT_MAP_GEN" | tee "$_AGENT_MAP_CACHE"
+fi
+unset _AGENT_MAP_CACHE _AGENT_MAP_GEN

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -649,15 +649,29 @@ codex() {
 # ── Agent Map: 起動時表示 ─────────────────────────────────────────────────────
 _AGENT_MAP_CACHE="$HOME/.cache/agent_map"
 _AGENT_MAP_GEN="$HOME/.config/zsh/agent_map_gen"
+mkdir -p "${_AGENT_MAP_CACHE:h}"
 if [[ -f "$_AGENT_MAP_CACHE" ]]; then
   cat "$_AGENT_MAP_CACHE"
   # キャッシュが1時間以上古ければバックグラウンドで更新（表示はブロックしない）
   if (( $(date +%s) - $(stat -f %m "$_AGENT_MAP_CACHE") > 3600 )); then
-    zsh "$_AGENT_MAP_GEN" > "$_AGENT_MAP_CACHE" &!
+    (
+      local _tmp
+      _tmp="$(mktemp "${_AGENT_MAP_CACHE}.tmp.XXXXXX")" || exit 1
+      if zsh "$_AGENT_MAP_GEN" > "$_tmp"; then
+        mv "$_tmp" "$_AGENT_MAP_CACHE"
+      else
+        rm -f "$_tmp"
+      fi
+    ) &!
   fi
 else
-  # 初回: 同期生成してキャッシュ保存
-  mkdir -p "${_AGENT_MAP_CACHE:h}"
-  zsh "$_AGENT_MAP_GEN" | tee "$_AGENT_MAP_CACHE"
+  # 初回: 同期生成してキャッシュ保存（tmpを経由してアトミックに）
+  local _tmp
+  _tmp="$(mktemp "${_AGENT_MAP_CACHE}.tmp.XXXXXX")" || return
+  if zsh "$_AGENT_MAP_GEN" | tee "$_tmp"; then
+    mv "$_tmp" "$_AGENT_MAP_CACHE"
+  else
+    rm -f "$_tmp"
+  fi
 fi
 unset _AGENT_MAP_CACHE _AGENT_MAP_GEN

--- a/zsh/agent_map_gen
+++ b/zsh/agent_map_gen
@@ -1,0 +1,191 @@
+#!/bin/zsh
+# agent_map_gen — Claude/Codex エージェント配置テーブルを生成して stdout へ出力
+# キャッシュ用途: ~/.config/zsh/agent_map_gen > ~/.cache/agent_map
+
+# ── ANSIカラー ────────────────────────────────────────────────────────────────
+ORANGE=$'\033[38;5;208m'
+GREEN=$'\033[38;5;82m'
+BOLD=$'\033[1m'
+DIM=$'\033[2m'
+GRAY=$'\033[38;5;240m'
+RESET=$'\033[0m'
+
+# ── カラムの可視幅 ─────────────────────────────────────────────────────────────
+W1=24   # Directory
+W2=18   # Agents
+W3=44   # Summary & Launch
+
+# ── ボックス描画 ───────────────────────────────────────────────────────────────
+_rep() { printf "%${1}s" | tr ' ' "$2"; }
+
+_hline() {
+  local l="$1" m="$2" r="$3"
+  printf "%s%s%s%s%s%s%s\n" \
+    "$l"  "$(_rep $((W1+2)) '─')" \
+    "$m"  "$(_rep $((W2+2)) '─')" \
+    "$m"  "$(_rep $((W3+2)) '─')" \
+    "$r"
+}
+
+# ── ファイルから1行サマリーを取得（CJK幅対応・ボイラープレート除外）──────────
+_summary() {
+  python3 - "$1" "$((W3-1))" <<'PYEOF'
+import sys, re, unicodedata
+
+file, maxw = sys.argv[1], int(sys.argv[2])
+
+SKIP = [
+    r'^This file provides guidance',
+    r'^Run the setup script',
+    r'^After making code changes',
+    r'^By default',
+    r'^Example',
+    r'^Never',
+    r'^Always',
+    r'^```', r'^\.',  r'^\d+\.', r'^[-*]\s',
+]
+
+def display_width(s):
+    return sum(2 if unicodedata.east_asian_width(c) in ('W','F') else 1 for c in s)
+
+def truncate_pad(s, w):
+    out, cur = [], 0
+    for c in s:
+        cw = 2 if unicodedata.east_asian_width(c) in ('W','F') else 1
+        if cur + cw > w: break
+        out.append(c); cur += cw
+    return ''.join(out) + ' ' * (w - cur)
+
+try:
+    lines = open(file).readlines()
+except:
+    print(' ' * maxw); sys.exit()
+
+GENERIC_TITLES = {'CLAUDE.md', 'AGENTS.md', 'Repository Guidelines', 'README'}
+
+# 1. # タイトル（汎用名でなければ最優先）
+for raw in lines:
+    line = raw.rstrip()
+    if line.startswith('# ') and not line.startswith('## '):
+        title = line[2:].strip()
+        if title not in GENERIC_TITLES:
+            print(truncate_pad(title, maxw)); sys.exit()
+        break  # 汎用タイトルなら次のステップへ
+
+# 2. 散文行（コード・リスト・定型文を除外）
+for raw in lines:
+    line = raw.rstrip()
+    if len(line) < 5 or line.startswith('#'): continue
+    if any(re.match(p, line) for p in SKIP): continue
+    if not (line[0].isalpha() or ord(line[0]) > 127): continue
+    if line.rstrip().endswith(':'): continue
+    if line[0].islower() and ord(line[0]) < 128: continue
+    clean = re.sub(r'`([^`]+)`', r'\1', line)  # バッククォートのマーカーだけ除去
+    if '`' in clean: continue
+    print(truncate_pad(clean, maxw)); sys.exit()
+
+# 3. ## セクションヘッダー
+for raw in lines:
+    line = raw.rstrip()
+    if line.startswith('## '):
+        print(truncate_pad(line[3:], maxw)); sys.exit()
+
+# 4. 汎用タイトルもフォールバック
+for raw in lines:
+    line = raw.rstrip()
+    if line.startswith('# ') and not line.startswith('## '):
+        print(truncate_pad(line[2:], maxw)); sys.exit()
+
+print(' ' * maxw)
+PYEOF
+}
+
+# ── エージェントバッジ（可視パディング済み・カラー付き）───────────────────────
+_badges() {
+  local has_c="$1" has_x="$2"
+  local vis=""
+  [[ $has_c == true ]] && vis+="[Claude]"
+  [[ $has_c == true && $has_x == true ]] && vis+=" "
+  [[ $has_x == true ]] && vis+="[Codex]"
+
+  local padded
+  padded=$(printf "%-${W2}s" "$vis")
+  padded="${padded/\[Claude\]/${ORANGE}[Claude]${RESET}}"
+  padded="${padded/\[Codex\]/${GREEN}[Codex]${RESET}}"
+  printf "%s" "$padded"
+}
+
+# ── 起動コマンド文字列 ─────────────────────────────────────────────────────────
+_cmd() {
+  local dir="$1" short="$2" has_c="$3" has_x="$4"
+  local s=""
+  if [[ "$dir" == "$HOME/.config" ]]; then
+    [[ $has_c == true ]] && s+="claude"
+    [[ $has_c == true && $has_x == true ]] && s+="  │  "
+    [[ $has_x == true ]] && s+="codex"
+  elif [[ $has_c == true && $has_x == true ]]; then
+    s="cd ${short} && claude  │  codex"
+  elif [[ $has_c == true ]]; then
+    s="cd ${short} && claude"
+  else
+    s="cd ${short} && codex"
+  fi
+  local padded
+  padded=$(printf "%-${W3}s" "$ ${s:0:$((W3-2))}")
+  printf "%s" "${DIM}${padded}${RESET}"
+}
+
+# ── プロジェクトスキャン ───────────────────────────────────────────────────────
+typeset -a PROJECTS
+
+_check() {
+  local dir="$1"
+  [[ -d "$dir" ]] || return
+  local has_c=false has_x=false
+  [[ -f "$dir/CLAUDE.md" ]] && has_c=true
+  [[ -f "$dir/AGENTS.md" ]] && has_x=true
+  [[ $has_c == false && $has_x == false ]] && return
+  PROJECTS+=("${dir}|${has_c}|${has_x}")
+}
+
+_check "$HOME/.config"
+for d in "$HOME/projects"/*/; do _check "${d%/}"; done
+for d in "$HOME/study"/*/;    do _check "${d%/}"; done
+_check "$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents/obsidian-private"
+
+# ── テーブル出力 ───────────────────────────────────────────────────────────────
+echo ""
+_hline "╭" "┬" "╮"
+
+printf "│ %b%-${W1}s%b │ %b%-${W2}s%b │ %b%-${W3}s%b │\n" \
+  "$BOLD" "Directory"        "$RESET" \
+  "$GRAY" "Agents"           "$RESET" \
+  "$GRAY" "Summary & Launch" "$RESET"
+
+for entry in "${PROJECTS[@]}"; do
+  dir="${entry%%|*}"
+  rest="${entry#*|}"
+  has_c="${rest%%|*}"
+  has_x="${rest##*|}"
+
+  short="${dir/#$HOME/~}"
+  (( ${#short} > W1 )) && short="…${short:$(( ${#short} - W1 + 1 ))}"
+
+  dir_col="${BOLD}$(printf "%-${W1}s" "$short")${RESET}"
+  badge_col="$(_badges "$has_c" "$has_x")"
+
+  # サマリー: AGENTS.md優先（よりプロジェクト向けの記述が多い）
+  if [[ $has_x == true ]]; then
+    sum_col="$(_summary "$dir/AGENTS.md")"
+  else
+    sum_col="$(_summary "$dir/CLAUDE.md")"
+  fi
+  cmd_col="$(_cmd "$dir" "$short" "$has_c" "$has_x")"
+
+  _hline "├" "┼" "┤"
+  printf "│ %b │ %b │ %b │\n" "$dir_col" "$badge_col" "$sum_col"
+  printf "│ %-${W1}s │ %-${W2}s │ %b │\n" "" "" "$cmd_col"
+done
+
+_hline "╰" "┴" "╯"
+echo ""

--- a/zsh/agent_map_gen
+++ b/zsh/agent_map_gen
@@ -16,7 +16,12 @@ W2=18   # Agents
 W3=44   # Summary & Launch
 
 # ── ボックス描画 ───────────────────────────────────────────────────────────────
-_rep() { printf "%${1}s" | tr ' ' "$2"; }
+_rep() {
+  local count="$1" char="$2" out=''
+  local i
+  for ((i = 0; i < count; i++)); do out+="$char"; done
+  printf "%s" "$out"
+}
 
 _hline() {
   local l="$1" m="$2" r="$3"

--- a/zsh/agent_map_gen
+++ b/zsh/agent_map_gen
@@ -154,8 +154,8 @@ _check() {
 }
 
 _check "$HOME/.config"
-for d in "$HOME/projects"/*/; do _check "${d%/}"; done
-for d in "$HOME/study"/*/;    do _check "${d%/}"; done
+for d in "$HOME/projects"/*(/N); do _check "${d%/}"; done
+for d in "$HOME/study"/*(/N);    do _check "${d%/}"; done
 _check "$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents/obsidian-private"
 
 # ── テーブル出力 ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `zsh/agent_map_gen` を新規追加: PC上の Claude/Codex エージェント設定 (`CLAUDE.md` / `AGENTS.md`) をスキャンし、色付きボックステーブルを生成
- `zsh/.zshrc` に起動時表示ロジックを追加: `~/.cache/agent_map` を `cat` するだけ（計算ゼロ）、1時間ごとにバックグラウンド自動更新

## 表示内容

| カラム | 内容 |
|--------|------|
| Directory | プロジェクトパス |
| Agents | `[Claude]`（オレンジ） / `[Codex]`（緑）バッジ |
| Summary & Launch | サマリー + コピペ起動コマンド |

## 技術仕様

- CJK文字（日本語）の表示幅を Python3 `unicodedata` で正確に計算
- スキャン対象: `~/projects/*/`, `~/study/*/`, `~/.config`, `~/Library/Mobile Documents/iCloud~md~obsidian/Documents/obsidian-private`
- キャッシュ: `~/.cache/agent_map`（ANSIカラー込みのレンダリング済みテキスト）

## Copilot レビュー対応 (ffcc8b5 / f545967 / 1bed359)

- `_rep()`: `tr` をzshループに変更（UTF-8 multibyte安全）
- グロブ: `*(/N)` 修飾子でNOMATCHエラーを防止
- キャッシュ書き込み: tmp + `mv` でアトミックに置換

🤖 Generated with [Claude Code](https://claude.com/claude-code)