### PR TITLE
feat/agent-map: エージェントマップ・Gruvbox テーマ・bin スクリプト

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-This repository is a personal dotfiles tree rooted at `~/.config`. Most directories map directly to one tool or app: `zsh/.zshrc`, `tmux/tmux.conf`, `wezterm/wezterm.lua`, `fish/config.fish`, `ghostty/config`, and `karabiner/karabiner.json`. Neovim lives in `nvim/` and is tracked as a Git submodule. `raycast/extensions/` contains packaged Raycast extensions with their own `package.json` files and build scripts. Treat generated assets such as `.map` files and app state under `configstore/` as managed outputs unless you are intentionally updating them.
+This repository is a personal dotfiles tree rooted at `~/.config`. Tracked directories in this repo map directly to one tool or app, including `zsh/.zshrc`, `tmux/tmux.conf`, `wezterm/wezterm.lua`, `ghostty/config`, and `karabiner/karabiner.json`. Neovim lives in `nvim/` and is tracked as a Git submodule. Paths such as `fish/config.fish` and `raycast/extensions/` may exist locally under `~/.config`, but they are local-only and gitignored rather than tracked in this repository. Treat generated assets such as `.map` files and app state under `configstore/` as managed outputs unless you are intentionally updating them.
 
 ## Build, Test, and Development Commands
 Clone into the expected path so configs resolve correctly:
@@ -22,7 +22,7 @@ npm run dev
 These scripts wrap `ray lint`, `ray build`, and `ray develop`.
 
 ## Coding Style & Naming Conventions
-Preserve each tool's native format: Lua in `nvim/` and `wezterm/`, shell-style syntax in `zsh/`, `fish/`, and `tmux/`, JSON in `karabiner/` and `configstore/`. Use 2-space indentation in JSON and the existing style elsewhere. Keep filenames conventional for the target tool, and prefer descriptive plugin or config names such as `lua/config/options.lua`. If you touch Neovim formatting, use `stylua`; Raycast extensions use `eslint`, `prettier`, and `ray lint`.
+Preserve each tool's native format: Lua in `nvim/` and `wezterm/`, shell-style syntax in `zsh/` and `tmux/`, JSON in `karabiner/` and `configstore/`. Use 2-space indentation in JSON and the existing style elsewhere. Keep filenames conventional for the target tool, and prefer descriptive plugin or config names such as `lua/config/options.lua`. If you touch Neovim formatting, use `stylua`; Raycast extensions use `eslint`, `prettier`, and `ray lint`.
 
 ## Testing Guidelines
 There is no repo-wide test suite. Validate changes with the narrowest relevant check: `npm run lint` or `npm run build` for Raycast extensions, and application-native reloads for shell and terminal configs. After editing user-facing keybindings or startup behavior, include a brief manual verification note in the PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+This repository is a personal dotfiles tree rooted at `~/.config`. Most directories map directly to one tool or app: `zsh/.zshrc`, `tmux/tmux.conf`, `wezterm/wezterm.lua`, `fish/config.fish`, `ghostty/config`, and `karabiner/karabiner.json`. Neovim lives in `nvim/` and is tracked as a Git submodule. `raycast/extensions/` contains packaged Raycast extensions with their own `package.json` files and build scripts. Treat generated assets such as `.map` files and app state under `configstore/` as managed outputs unless you are intentionally updating them.
+
+## Build, Test, and Development Commands
+Clone into the expected path so configs resolve correctly:
+
+```sh
+git clone git@github.com/ohikouta/dotfiles.git ~/.config
+cd ~/.config && git submodule update --init --recursive
+```
+
+For Neovim submodule updates, pull inside `nvim/` and then commit the submodule pointer from the repo root. For Raycast extensions, run commands from the relevant extension directory, for example:
+
+```sh
+npm run lint
+npm run build
+npm run dev
+```
+
+These scripts wrap `ray lint`, `ray build`, and `ray develop`.
+
+## Coding Style & Naming Conventions
+Preserve each tool's native format: Lua in `nvim/` and `wezterm/`, shell-style syntax in `zsh/`, `fish/`, and `tmux/`, JSON in `karabiner/` and `configstore/`. Use 2-space indentation in JSON and the existing style elsewhere. Keep filenames conventional for the target tool, and prefer descriptive plugin or config names such as `lua/config/options.lua`. If you touch Neovim formatting, use `stylua`; Raycast extensions use `eslint`, `prettier`, and `ray lint`.
+
+## Testing Guidelines
+There is no repo-wide test suite. Validate changes with the narrowest relevant check: `npm run lint` or `npm run build` for Raycast extensions, and application-native reloads for shell and terminal configs. After editing user-facing keybindings or startup behavior, include a brief manual verification note in the PR.
+
+## Commit & Pull Request Guidelines
+Recent history uses short, scoped commit subjects such as `wezterm:...`, `feat:...`, and `chore:...`; follow that pattern and keep commits focused to one tool or behavior change. Pull requests should explain what changed, which app or config area is affected, how you verified it, and include screenshots only when UI-visible behavior changed.
+
+## Security & Configuration Tips
+Do not commit secrets, tokens, machine-specific host data, or transient caches. Review diffs in `configstore/`, `gh/hosts.yml`, and Raycast extension settings carefully before committing.

--- a/bin/cmux
+++ b/bin/cmux
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# cmux dev shim (managed by scripts/reload.sh)
+set -euo pipefail
+
+CLI_PATH_FILE="/tmp/cmux-last-cli-path"
+CLI_PATH_OWNER="$(stat -f '%u' "$CLI_PATH_FILE" 2>/dev/null || stat -c '%u' "$CLI_PATH_FILE" 2>/dev/null || echo -1)"
+if [[ -r "$CLI_PATH_FILE" ]] && [[ ! -L "$CLI_PATH_FILE" ]] && [[ "$CLI_PATH_OWNER" == "$(id -u)" ]]; then
+  CLI_PATH="$(cat "$CLI_PATH_FILE")"
+  if [[ -x "$CLI_PATH" ]]; then
+    exec "$CLI_PATH" "$@"
+  fi
+fi
+
+if [[ -x "/Applications/cmux.app/Contents/Resources/bin/cmux" ]]; then
+  exec "/Applications/cmux.app/Contents/Resources/bin/cmux" "$@"
+fi
+
+echo "error: no reload-selected dev cmux CLI found. Run ./scripts/reload.sh --tag <name> first." >&2
+exit 1

--- a/bin/codex-startup-dashboard
+++ b/bin/codex-startup-dashboard
@@ -1,0 +1,111 @@
+#!/bin/zsh
+
+setopt local_options no_unset
+
+short_path() {
+  local path="$1"
+  path="${path/#$HOME/~}"
+  printf '%s' "$path"
+}
+
+first_heading() {
+  local file="$1"
+  [[ -f "$file" ]] || return 1
+  awk '/^# / {sub(/^# /, "", $0); print; exit}' "$file"
+}
+
+describe_agent_dir() {
+  local dir="$1"
+  case "$dir" in
+    "$HOME/.config")
+      echo "dotfiles と shell・tmux・editor・terminal の設定"
+      return
+      ;;
+    "$HOME/projects/vue-chat")
+      echo "Vue と Firebase を使うチャットアプリ"
+      return
+      ;;
+    "$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents/obsidian-private")
+      echo "Obsidian vault の整理・参照・下書き担当"
+      return
+      ;;
+  esac
+
+  local readme heading
+  for readme in "$dir/README.md" "$dir/readme.md"; do
+    heading="$(first_heading "$readme")"
+    [[ -n "$heading" ]] && {
+      echo "$heading"
+      return
+    }
+  done
+
+  echo "AGENTS.md が配置されたディレクトリ"
+}
+
+print_shortcuts() {
+  printf 'よく使う導線\n'
+  printf '  %-28s %s\n' "$(short_path "$HOME/.codex")" "Codex の設定・セッション・skills"
+  printf '  %-28s %s\n' "$(short_path "$HOME/.config")" "dotfiles と端末まわりの設定"
+  printf '  %-28s %s\n' "$(short_path "$HOME/projects")" "プロジェクトのルート"
+
+  local obsidian="$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents/obsidian-private"
+  if [[ -d "$obsidian" ]]; then
+    printf '  %-28s %s\n' "$(short_path "$obsidian")" "Obsidian vault"
+  fi
+
+  if [[ -d "$HOME/projects/agent-playbook" ]]; then
+    printf '  %-28s %s\n' "$(short_path "$HOME/projects/agent-playbook")" "エージェント共通運用のテンプレート"
+  fi
+}
+
+print_launch_commands() {
+  printf '起動コマンド\n'
+  printf '  %s\n' "cd \"$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents/obsidian-private\" && codex"
+  printf '  %s\n' "cd \"$HOME/projects/vue-chat\" && codex"
+  printf '  %s\n' "cd \"$HOME/.config\" && codex"
+}
+
+print_agent_dirs() {
+  printf 'エージェント関連ディレクトリ\n'
+
+  local -a search_roots=(
+    "$HOME/.config"
+    "$HOME/projects"
+    "$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents/obsidian-private"
+  )
+  local -a agent_files
+  local file dir summary
+  local -A seen_dirs
+
+  agent_files=("${(@f)$(find "${search_roots[@]}" -name AGENTS.md -not -path '*/.git/*' -not -path '*/node_modules/*' 2>/dev/null | sort)}")
+
+  if (( ${#agent_files[@]} == 0 )); then
+    printf '  （見つかりませんでした）\n'
+    return
+  fi
+
+  for file in "${agent_files[@]}"; do
+    dir="${file:h}"
+    [[ -n "${seen_dirs[$dir]-}" ]] && continue
+    seen_dirs[$dir]=1
+    summary="$(describe_agent_dir "$dir")"
+    printf '  %-28s %s\n' "$(short_path "$dir")" "$summary"
+  done
+}
+
+main() {
+  [[ "${CODEX_STARTUP_DASHBOARD:-1}" == "0" ]] && return 0
+  [[ "${1:-}" == "--force" || -t 1 ]] || return 0
+
+  printf '\n'
+  printf '== Codex 起動ガイド ==\n'
+  print_shortcuts
+  printf '\n'
+  print_agent_dirs
+  printf '\n'
+  print_launch_commands
+  printf '\n'
+}
+
+main "$@"

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -25,9 +25,8 @@ bind -T copy-mode-vi y send -X copy-selection-and-cancel
 set -g pane-border-status top
 set -g pane-border-lines heavy
 set -g pane-border-indicators both
-set -g pane-border-style "fg=colour238"
-set -g pane-active-border-style "fg=colour81"
-set -g pane-border-format '#{?@pane_label,#{?pane_active,#{[fg=colour231,bg=colour33,bold]},#{[fg=colour252,bg=colour238]}} #{@pane_label} #{[default]},#{?pane_active,#{[fg=colour231,bg=colour33,bold]},#{[fg=colour252,bg=colour238]}} #{pane_current_path} #{?#{!=:#{pane_title},},{host},| #{pane_title} }#{[default]}}'
+# pane-border-style / pane-active-border-style は Gruvbox セクションで設定
+set -g pane-border-format '#{?@pane_label,#{?pane_active,#{[fg=colour231,bg=colour33,bold]},#{[fg=colour252,bg=colour238]}} #{@pane_label} #{[default]},#{?pane_active,#{[fg=colour231,bg=colour33,bold]},#{[fg=colour252,bg=colour238]}} #{pane_current_path} #{host}#{?#{!=:#{pane_title},#{host}}, | #{pane_title},}#{[default]}}'
 
 # Resize pane
 bind -n M-Left resize-pane -L
@@ -75,7 +74,7 @@ set -g window-status-current-style "bg=#fe8019,fg=#282828,bold"
 # ウィンドウタブ区切り
 set -g window-status-separator ""
 
-# ペイン区切り線（Gruvbox カラーで上書き）
+# ペイン区切り線（Gruvbox カラー）
 set -g pane-border-style "fg=#504945"
 set -g pane-active-border-style "fg=#fe8019"
 

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -27,7 +27,7 @@ set -g pane-border-lines heavy
 set -g pane-border-indicators both
 set -g pane-border-style "fg=colour238"
 set -g pane-active-border-style "fg=colour81"
-set -g pane-border-format '#{?@pane_label,#{?pane_active,#[fg=colour231,bg=colour33,bold],#[fg=colour252,bg=colour238]} #{@pane_label} #[default],#{?pane_active,#[fg=colour231,bg=colour33,bold],#[fg=colour252,bg=colour238]} #{pane_current_path} #{?#{!=:#{pane_title},#{host}},| #{pane_title} ,}#[default]}'
+set -g pane-border-format '#{?@pane_label,#{?pane_active,#{[fg=colour231,bg=colour33,bold]},#{[fg=colour252,bg=colour238]}} #{@pane_label} #{[default]},#{?pane_active,#{[fg=colour231,bg=colour33,bold]},#{[fg=colour252,bg=colour238]}} #{pane_current_path} #{?#{!=:#{pane_title},},{host},| #{pane_title} }#{[default]}}'
 
 # Resize pane
 bind -n M-Left resize-pane -L
@@ -41,3 +41,47 @@ bind -n M-l resize-pane -R
 
 # Ask tmux to expose copied text to the terminal clipboard when supported.
 set -g set-clipboard external
+
+# =============================================================
+# Gruvbox テーマ
+# =============================================================
+
+# 256色・True Color 有効化
+set -g default-terminal "screen-256color"
+set -ag terminal-overrides ",xterm-256color:RGB"
+
+# ステータスバー 全体
+set -g status on
+set -g status-interval 5
+set -g status-position bottom
+set -g status-style "bg=#1d2021,fg=#928374"
+
+# ステータスバー 左：セッション名
+set -g status-left-length 40
+set -g status-left "#[bg=#b8bb26,fg=#282828,bold] #S #[bg=#1d2021,fg=#b8bb26] "
+
+# ステータスバー 右：時刻・日付
+set -g status-right-length 60
+set -g status-right "#[fg=#928374]%Y-%m-%d #[bg=#fabd2f,fg=#282828,bold] %H:%M "
+
+# ウィンドウタブ（非アクティブ）
+set -g window-status-format "#[fg=#928374] #I #W "
+set -g window-status-style "fg=#928374,bg=#1d2021"
+
+# ウィンドウタブ（アクティブ）
+set -g window-status-current-format "#[bg=#fe8019,fg=#282828,bold] #I #W "
+set -g window-status-current-style "bg=#fe8019,fg=#282828,bold"
+
+# ウィンドウタブ区切り
+set -g window-status-separator ""
+
+# ペイン区切り線（Gruvbox カラーで上書き）
+set -g pane-border-style "fg=#504945"
+set -g pane-active-border-style "fg=#fe8019"
+
+# コピーモード（Gruvbox カラー）
+set -g mode-style "bg=#fe8019,fg=#282828"
+
+# メッセージバー
+set -g message-style "bg=#fabd2f,fg=#282828,bold"
+set -g message-command-style "bg=#1d2021,fg=#fabd2f"


### PR DESCRIPTION
## 変更内容

### zsh: Agent Map（既存コミット）
- 起動時にエージェント配置テーブルを表示
- `agent_map_gen` の各種改善（グロブ修飾子、zsh ネイティブループ、アトミックキャッシュ書き込み）

### tmux: Gruvbox テーマ追加・pane-border-format 構文修正
- `pane-border-format` の `#[]` 記法を `#{[]}` 形式に修正（tmux 3.5+ 対応）
- ステータスバー・ウィンドウタブ・ペイン区切り・コピーモード・メッセージバーを Gruvbox カラーで統一

### feat: AGENTS.md と bin スクリプト追加
- `AGENTS.md`: リポジトリのプロジェクト構成・規約ガイド
- `bin/codex-startup-dashboard`: Codex 起動時にエージェント関連ディレクトリ・導線・起動コマンドを表示
- `bin/cmux`: cmux dev shim

### nvim: サブモジュールポインタ更新

## 検証
- tmux: `tmux source-file ~/.config/tmux/tmux.conf` でリロード後、ステータスバーの色を目視確認
- codex-startup-dashboard: `~/.config/bin/codex-startup-dashboard` を実行してダッシュボード表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)