### PR TITLE
zsh: agent_map — スキャンパスを端末ごとのローカル設定に分離

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ raycast/
 
 # machine-local private config
 zsh/.zshrc.local
+zsh/agent_map_local
 
 # AWS VPN
 AWS VPN Client/

--- a/zsh/agent_map_gen
+++ b/zsh/agent_map_gen
@@ -1,16 +1,28 @@
 #!/bin/zsh
 # agent_map_gen — エージェント配置一覧を生成して stdout へ出力
+# スキャン対象は ~/.config/zsh/agent_map_local に記述（gitignore対象）
 
 ORANGE=$'\033[38;5;208m'
 GREEN=$'\033[38;5;82m'
 DIM=$'\033[2m'
 RESET=$'\033[0m'
 
+LOCAL_CONF="${HOME}/.config/zsh/agent_map_local"
+
+# ── ローカル設定ファイルがなければ終了 ───────────────────────────────────────
+if [[ ! -f "$LOCAL_CONF" ]]; then
+  echo ""
+  printf "  ${DIM}agent map: %s が未作成です。agent_map_local.example を参照。${RESET}\n" \
+    "~/.config/zsh/agent_map_local"
+  echo ""
+  exit 0
+fi
+
 # ── プロジェクトスキャン ──────────────────────────────────────────────────────
 typeset -a ROWS
 
 _check() {
-  local dir="$1"
+  local dir="${1/#\~/$HOME}"   # ~ を展開
   [[ -d "$dir" ]] || return
   local has_c=false has_x=false
   [[ -f "$dir/CLAUDE.md" ]] && has_c=true
@@ -19,10 +31,12 @@ _check() {
   ROWS+=("${dir}|${has_c}|${has_x}")
 }
 
-_check "$HOME/.config"
-for d in "$HOME/projects"/*(/N); do _check "${d%/}"; done
-for d in "$HOME/study"/*(/N);    do _check "${d%/}"; done
-_check "$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents/obsidian-private"
+# agent_map_local を1行ずつ読む（# コメント・空行はスキップ）
+while IFS= read -r line || [[ -n "$line" ]]; do
+  [[ "$line" =~ ^[[:space:]]*# ]] && continue
+  [[ -z "${line// }" ]] && continue
+  _check "$line"
+done < "$LOCAL_CONF"
 
 # ── cd パス（短縮）────────────────────────────────────────────────────────────
 _cd_path() {

--- a/zsh/agent_map_local.example
+++ b/zsh/agent_map_local.example
@@ -1,0 +1,9 @@
+# agent_map_local — この端末でスキャンするエージェントディレクトリ
+# ~/.config/zsh/agent_map_local にコピーして使用（gitignore対象）
+# 1行1パス。~ 展開対応。# はコメント。
+
+~/.config
+~/projects/foo
+~/projects/bar
+~/study/math
+~/Library/Mobile Documents/iCloud~md~obsidian/Documents/obsidian-private


### PR DESCRIPTION
## 背景

複数端末でdotfilesを共有した際、私用端末のエージェント情報が仕事用端末にも表示されてしまう問題があった。

## 変更内容

- `agent_map_gen` のスキャンパスをハードコードから `agent_map_local`（gitignore対象）を読む形に変更
- `agent_map_local.example` を追加（フォーマット説明付きサンプル）
- `.gitignore` に `zsh/agent_map_local` を追加

## 挙動

| 状態 | 表示 |
|------|------|
| `agent_map_local` あり | その端末のエージェント一覧を表示 |
| `agent_map_local` なし | セットアップ手順のヒントを表示 |

## 仕事用端末でのセットアップ手順（README相当）

```sh
# 1. dotfilesをpull
cd ~/.config && git pull

# 2. ローカル設定を作成
cp ~/.config/zsh/agent_map_local.example ~/.config/zsh/agent_map_local

# 3. その端末のプロジェクトパスに編集
vim ~/.config/zsh/agent_map_local

# 4. キャッシュを再生成
zsh ~/.config/zsh/agent_map_gen > ~/.cache/agent_map
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)