### PR TITLE
zsh: agent_map_local — ワイルドカード対応

### DIFF
--- a/zsh/agent_map_gen
+++ b/zsh/agent_map_gen
@@ -32,10 +32,16 @@ _check() {
 }
 
 # agent_map_local を1行ずつ読む（# コメント・空行はスキップ）
+# ワイルドカード（例: ~/Documents/*/）はグロブ展開してサブディレクトリを全スキャン
 while IFS= read -r line || [[ -n "$line" ]]; do
   [[ "$line" =~ ^[[:space:]]*# ]] && continue
   [[ -z "${line// }" ]] && continue
-  _check "$line"
+  local expanded="${line/#\~/$HOME}"
+  if [[ "$line" == *'*'* ]]; then
+    for d in ${~expanded}(/N); do _check "${d%/}"; done
+  else
+    _check "$line"
+  fi
 done < "$LOCAL_CONF"
 
 # ── cd パス（短縮）────────────────────────────────────────────────────────────

--- a/zsh/agent_map_local.example
+++ b/zsh/agent_map_local.example
@@ -1,9 +1,9 @@
 # agent_map_local — この端末でスキャンするエージェントディレクトリ
 # ~/.config/zsh/agent_map_local にコピーして使用（gitignore対象）
 # 1行1パス。~ 展開対応。# はコメント。
+# ワイルドカード使用可: ~/Documents/*/ と書けばサブディレクトリを全スキャン
 
 ~/.config
-~/projects/foo
-~/projects/bar
-~/study/math
+~/Documents/*/
+~/projects/specific-repo
 ~/Library/Mobile Documents/iCloud~md~obsidian/Documents/obsidian-private


### PR DESCRIPTION
## 背景

仕事用端末で \`~/Documents\` と書いても直下に \`CLAUDE.md\` がないため何も表示されなかった。プロジェクトはサブディレクトリに存在するため、一括スキャンが必要。

## 変更内容

- \`agent_map_gen\`: \`agent_map_local\` の行に \`*\` が含まれる場合はグロブ展開してサブディレクトリを全スキャン
- \`agent_map_local.example\`: ワイルドカードの使い方を追記

## 使い方

```
# agent_map_local の記述例
~/.config
~/Documents/*/    ← Documents以下のサブディレクトリを全スキャン
~/projects/specific-repo    ← 個別指定も引き続き可能
```

## 仕事用端末での対応

\`agent_map_local\` を以下のように更新してリロード：

```sh
vim ~/.config/zsh/agent_map_local
# ~/Documents/*/ に変更して保存

source ~/.zshrc
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)